### PR TITLE
feat(song-sorter): icon-grid character picker with franchise tabs

### DIFF
--- a/src/components/sorter/CharacterGridSelector.tsx
+++ b/src/components/sorter/CharacterGridSelector.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LuCheck } from 'react-icons/lu';
+import { Dialog } from '~/components/ui/dialog';
+import { Button } from '~/components/ui/button';
+import { Input } from '~/components/ui/input';
+import { Text } from '~/components/ui/text';
+import { Badge } from '~/components/ui/badge';
+import { Box, Center, Grid, HStack, Stack, styled } from 'styled-system/jsx';
+import seriesInfo from '../../../data/series-info.json';
+import type { Character } from '~/types';
+import type { Locale } from '~/i18n';
+import { getPicUrl } from '~/utils/assets';
+import { getCastName, getFullName } from '~/utils/character';
+import { fuzzySearch } from '~/utils/search';
+
+interface CharacterGridSelectorProps {
+  title: string;
+  triggerLabel?: string;
+  characters: Character[];
+  selectedIds: number[];
+  onSelectionChange: (ids: number[]) => void;
+}
+
+/** Emblem icon with a portrait-art fallback for characters that have no icon. */
+function CharacterTileImage({ character, locale }: { character: Character; locale: Locale }) {
+  const [iconError, setIconError] = useState(false);
+
+  useEffect(() => {
+    setIconError(false);
+  }, [character.id]);
+
+  const fullName = getFullName(character, locale);
+
+  if (character.hasIcon && !iconError) {
+    return (
+      <styled.img
+        src={getPicUrl(character.id, 'icons')}
+        alt={`${fullName} Icon`}
+        onError={() => setIconError(true)}
+        maxW="70%"
+        maxH="70%"
+        objectFit="contain"
+      />
+    );
+  }
+
+  // Full-body sprites: anchor to the top so the face stays visible instead of
+  // being cropped out by a centered cover.
+  return (
+    <styled.img
+      src={getPicUrl(character.id, 'character')}
+      alt={fullName}
+      w="full"
+      h="full"
+      objectFit="cover"
+      objectPosition="center top"
+    />
+  );
+}
+
+export function CharacterGridSelector({
+  title,
+  triggerLabel,
+  characters,
+  selectedIds,
+  onSelectionChange
+}: CharacterGridSelectorProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language as Locale;
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<string>('ALL');
+  const [tempSelectedIds, setTempSelectedIds] = useState<number[]>([]);
+
+  const handleOpen = () => {
+    setTempSelectedIds([...selectedIds]);
+    setSearchQuery('');
+    setSelectedCategory('ALL');
+    setIsOpen(true);
+  };
+
+  const handleSave = () => {
+    onSelectionChange(tempSelectedIds);
+    setIsOpen(false);
+  };
+
+  const toggle = (id: number) => {
+    setTempSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]));
+  };
+
+  const filtered = useMemo(() => {
+    if (!searchQuery.trim()) return characters;
+    return characters.filter((c) =>
+      fuzzySearch(
+        {
+          id: c.id,
+          name: c.fullName,
+          englishName: c.englishName ?? undefined,
+          phoneticName: c.casts?.map((cast) => `${cast.seiyuu} ${cast.englishName ?? ''}`).join(' ')
+        },
+        searchQuery
+      )
+    );
+  }, [characters, searchQuery]);
+
+  // Series that actually have characters available — drives the tab list.
+  // Based on the unfiltered `characters` so tabs stay stable while searching.
+  const availableSeries = useMemo(
+    () =>
+      seriesInfo.filter((s) =>
+        characters.some((c) => String(c.seriesId) === String(s.id))
+      ),
+    [characters]
+  );
+
+  // Group by series (canonical order), honoring the active franchise tab.
+  const groups = useMemo(() => {
+    return seriesInfo
+      .filter((s) => selectedCategory === 'ALL' || s.id === selectedCategory)
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        color: s.color,
+        items: filtered.filter((c) => String(c.seriesId) === String(s.id))
+      }))
+      .filter((g) => g.items.length > 0);
+  }, [filtered, selectedCategory]);
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(e) => setIsOpen(e.open)}>
+      <Dialog.Trigger asChild>
+        <Button variant="outline" size="sm" onClick={handleOpen}>
+          {triggerLabel || title}
+          {selectedIds.length > 0 && <Badge ml="2">{selectedIds.length}</Badge>}
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Backdrop />
+      <Dialog.Positioner>
+        <Dialog.Content
+          display="flex"
+          flexDirection="column"
+          w="100%"
+          maxW="4xl"
+          h="85vh"
+          maxH="85vh"
+        >
+          <Stack gap="4" h="full" p="6">
+            <HStack justifyContent="space-between" alignItems="center">
+              <Dialog.Title>{title}</Dialog.Title>
+              <Badge variant="solid" size="sm">
+                {tempSelectedIds.length}
+              </Badge>
+            </HStack>
+
+            <Input
+              placeholder={t('common.search')}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+
+            {availableSeries.length > 1 && (
+              <HStack gap="2" pb="1" overflowX="auto">
+                <Button
+                  size="xs"
+                  variant={selectedCategory === 'ALL' ? 'solid' : 'outline'}
+                  onClick={() => setSelectedCategory('ALL')}
+                  flexShrink="0"
+                >
+                  {t('common.all')}
+                </Button>
+                {availableSeries.map((s) => (
+                  <Button
+                    key={s.id}
+                    size="xs"
+                    variant={selectedCategory === s.id ? 'subtle' : 'outline'}
+                    onClick={() => setSelectedCategory(s.id)}
+                    flexShrink="0"
+                    style={{
+                      borderColor: s.color,
+                      backgroundColor: selectedCategory === s.id ? s.color : undefined,
+                      color: selectedCategory === s.id ? 'white' : s.color
+                    }}
+                  >
+                    {s.name}
+                  </Button>
+                ))}
+              </HStack>
+            )}
+
+            <Box flex="1" overflowY="auto" mx="-2" px="2">
+              {groups.length === 0 ? (
+                <Text py="4" color="fg.muted" textAlign="center">
+                  {t('common.no_items')}
+                </Text>
+              ) : (
+                <Stack gap="6">
+                  {groups.map((group) => (
+                    <Stack key={group.id} gap="3">
+                      <HStack gap="2" alignItems="center" position="sticky" top="0" bg="bg.canvas" py="1" zIndex="1">
+                        <Box w="1" h="5" rounded="full" style={{ backgroundColor: group.color }} />
+                        <Text fontWeight="bold" style={{ color: group.color }}>
+                          {group.name}
+                        </Text>
+                      </HStack>
+                      <Grid gridGap="2" gridTemplateColumns="repeat(auto-fill, minmax(140px, 1fr))">
+                        {group.items.map((c) => {
+                          const id = Number(c.id);
+                          const isSelected = tempSelectedIds.includes(id);
+                          const color = c.colorCode ?? c.seriesColor ?? group.color;
+                          return (
+                            <styled.button
+                              key={c.id}
+                              type="button"
+                              onClick={() => toggle(id)}
+                              aria-pressed={isSelected}
+                              cursor="pointer"
+                              display="flex"
+                              flexDirection="column"
+                              gap="2"
+                              p="2"
+                              rounded="l2"
+                              borderWidth="2px"
+                              transition="all 0.15s"
+                              alignItems="center"
+                              textAlign="center"
+                              bg="bg.canvas"
+                              style={{
+                                borderColor: isSelected ? color : 'transparent',
+                                boxShadow: isSelected ? `0 0 0 1px ${color}` : undefined
+                              }}
+                              _hover={{ bg: 'bg.subtle' }}
+                            >
+                              <Center
+                                position="relative"
+                                w="full"
+                                aspectRatio="1"
+                                rounded="l1"
+                                bg="bg.muted"
+                                overflow="hidden"
+                              >
+                                <CharacterTileImage character={c} locale={locale} />
+                                {isSelected && (
+                                  <Center
+                                    position="absolute"
+                                    top="1"
+                                    right="1"
+                                    w="6"
+                                    h="6"
+                                    rounded="full"
+                                    color="white"
+                                    style={{ backgroundColor: color }}
+                                  >
+                                    <LuCheck />
+                                  </Center>
+                                )}
+                              </Center>
+                              <Stack gap="0.5" alignItems="center" w="full">
+                                <Text
+                                  fontWeight="bold"
+                                  fontSize="sm"
+                                  textAlign="center"
+                                  truncate
+                                  maxW="full"
+                                >
+                                  {getFullName(c, locale)}
+                                </Text>
+                                {c.casts?.[0] && (
+                                  <Text fontSize="xs" color="fg.muted" textAlign="center">
+                                    {getCastName(c.casts[0], locale)}
+                                  </Text>
+                                )}
+                              </Stack>
+                            </styled.button>
+                          );
+                        })}
+                      </Grid>
+                    </Stack>
+                  ))}
+                </Stack>
+              )}
+            </Box>
+
+            <HStack gap="4" justify="space-between">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setTempSelectedIds([])}
+                disabled={tempSelectedIds.length === 0}
+              >
+                {t('settings.deselect_all')}
+              </Button>
+              <HStack gap="4">
+                <Dialog.CloseTrigger asChild>
+                  <Button variant="outline" onClick={() => setIsOpen(false)}>
+                    {t('common.cancel')}
+                  </Button>
+                </Dialog.CloseTrigger>
+                <Button onClick={handleSave}>{t('common.confirm')}</Button>
+              </HStack>
+            </HStack>
+          </Stack>
+          <Dialog.CloseTrigger />
+        </Dialog.Content>
+      </Dialog.Positioner>
+    </Dialog.Root>
+  );
+}

--- a/src/components/sorter/CharacterGridSelector.tsx
+++ b/src/components/sorter/CharacterGridSelector.tsx
@@ -24,11 +24,9 @@ interface CharacterGridSelectorProps {
 
 /** Emblem icon with a portrait-art fallback for characters that have no icon. */
 function CharacterTileImage({ character, locale }: { character: Character; locale: Locale }) {
+  // Tiles are keyed by character id, so a given instance never switches
+  // characters — once an emblem 404s the fallback should stick for its lifetime.
   const [iconError, setIconError] = useState(false);
-
-  useEffect(() => {
-    setIconError(false);
-  }, [character.id]);
 
   const fullName = getFullName(character, locale);
 
@@ -37,6 +35,7 @@ function CharacterTileImage({ character, locale }: { character: Character; local
       <styled.img
         src={getPicUrl(character.id, 'icons')}
         alt={`${fullName} Icon`}
+        loading="lazy"
         onError={() => setIconError(true)}
         maxW="70%"
         maxH="70%"
@@ -51,6 +50,7 @@ function CharacterTileImage({ character, locale }: { character: Character; local
     <styled.img
       src={getPicUrl(character.id, 'character')}
       alt={fullName}
+      loading="lazy"
       w="full"
       h="full"
       objectFit="cover"
@@ -113,6 +113,14 @@ export function CharacterGridSelector({
       ),
     [characters]
   );
+
+  // If the active franchise tab disappears (e.g. the series filter changes while
+  // the dialog is open), fall back to "All" so the grid never goes empty.
+  useEffect(() => {
+    if (selectedCategory !== 'ALL' && !availableSeries.some((s) => s.id === selectedCategory)) {
+      setSelectedCategory('ALL');
+    }
+  }, [availableSeries, selectedCategory]);
 
   // Group by series (canonical order), honoring the active franchise tab.
   const groups = useMemo(() => {

--- a/src/components/sorter/CharacterGridSelector.tsx
+++ b/src/components/sorter/CharacterGridSelector.tsx
@@ -37,9 +37,9 @@ function CharacterTileImage({ character, locale }: { character: Character; local
         alt={`${fullName} Icon`}
         loading="lazy"
         onError={() => setIconError(true)}
+        objectFit="contain"
         maxW="70%"
         maxH="70%"
-        objectFit="contain"
       />
     );
   }
@@ -51,10 +51,10 @@ function CharacterTileImage({ character, locale }: { character: Character; local
       src={getPicUrl(character.id, 'character')}
       alt={fullName}
       loading="lazy"
+      objectPosition="center top"
+      objectFit="cover"
       w="full"
       h="full"
-      objectFit="cover"
-      objectPosition="center top"
     />
   );
 }
@@ -86,7 +86,9 @@ export function CharacterGridSelector({
   };
 
   const toggle = (id: number) => {
-    setTempSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]));
+    setTempSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
+    );
   };
 
   const filtered = useMemo(() => {
@@ -107,10 +109,7 @@ export function CharacterGridSelector({
   // Series that actually have characters available — drives the tab list.
   // Based on the unfiltered `characters` so tabs stay stable while searching.
   const availableSeries = useMemo(
-    () =>
-      seriesInfo.filter((s) =>
-        characters.some((c) => String(c.seriesId) === String(s.id))
-      ),
+    () => seriesInfo.filter((s) => characters.some((c) => String(c.seriesId) === String(s.id))),
     [characters]
   );
 
@@ -183,12 +182,12 @@ export function CharacterGridSelector({
                     size="xs"
                     variant={selectedCategory === s.id ? 'subtle' : 'outline'}
                     onClick={() => setSelectedCategory(s.id)}
-                    flexShrink="0"
                     style={{
                       borderColor: s.color,
                       backgroundColor: selectedCategory === s.id ? s.color : undefined,
                       color: selectedCategory === s.id ? 'white' : s.color
                     }}
+                    flexShrink="0"
                   >
                     {s.name}
                   </Button>
@@ -196,7 +195,7 @@ export function CharacterGridSelector({
               </HStack>
             )}
 
-            <Box flex="1" overflowY="auto" mx="-2" px="2">
+            <Box flex="1" mx="-2" px="2" overflowY="auto">
               {groups.length === 0 ? (
                 <Text py="4" color="fg.muted" textAlign="center">
                   {t('common.no_items')}
@@ -205,9 +204,17 @@ export function CharacterGridSelector({
                 <Stack gap="6">
                   {groups.map((group) => (
                     <Stack key={group.id} gap="3">
-                      <HStack gap="2" alignItems="center" position="sticky" top="0" bg="bg.canvas" py="1" zIndex="1">
-                        <Box w="1" h="5" rounded="full" style={{ backgroundColor: group.color }} />
-                        <Text fontWeight="bold" style={{ color: group.color }}>
+                      <HStack
+                        zIndex="1"
+                        position="sticky"
+                        top="0"
+                        gap="2"
+                        alignItems="center"
+                        py="1"
+                        bg="bg.canvas"
+                      >
+                        <Box style={{ backgroundColor: group.color }} rounded="full" w="1" h="5" />
+                        <Text style={{ color: group.color }} fontWeight="bold">
                           {group.name}
                         </Text>
                       </HStack>
@@ -222,42 +229,42 @@ export function CharacterGridSelector({
                               type="button"
                               onClick={() => toggle(id)}
                               aria-pressed={isSelected}
-                              cursor="pointer"
-                              display="flex"
-                              flexDirection="column"
-                              gap="2"
-                              p="2"
-                              rounded="l2"
-                              borderWidth="2px"
-                              transition="all 0.15s"
-                              alignItems="center"
-                              textAlign="center"
-                              bg="bg.canvas"
                               style={{
                                 borderColor: isSelected ? color : 'transparent',
                                 boxShadow: isSelected ? `0 0 0 1px ${color}` : undefined
                               }}
+                              cursor="pointer"
+                              display="flex"
+                              gap="2"
+                              flexDirection="column"
+                              alignItems="center"
+                              rounded="l2"
+                              borderWidth="2px"
+                              p="2"
+                              textAlign="center"
+                              bg="bg.canvas"
+                              transition="all 0.15s"
                               _hover={{ bg: 'bg.subtle' }}
                             >
                               <Center
                                 position="relative"
-                                w="full"
                                 aspectRatio="1"
                                 rounded="l1"
+                                w="full"
                                 bg="bg.muted"
                                 overflow="hidden"
                               >
                                 <CharacterTileImage character={c} locale={locale} />
                                 {isSelected && (
                                   <Center
+                                    style={{ backgroundColor: color }}
                                     position="absolute"
                                     top="1"
                                     right="1"
+                                    rounded="full"
                                     w="6"
                                     h="6"
-                                    rounded="full"
                                     color="white"
-                                    style={{ backgroundColor: color }}
                                   >
                                     <LuCheck />
                                   </Center>
@@ -265,16 +272,16 @@ export function CharacterGridSelector({
                               </Center>
                               <Stack gap="0.5" alignItems="center" w="full">
                                 <Text
-                                  fontWeight="bold"
+                                  maxW="full"
                                   fontSize="sm"
+                                  fontWeight="bold"
                                   textAlign="center"
                                   truncate
-                                  maxW="full"
                                 >
                                   {getFullName(c, locale)}
                                 </Text>
                                 {c.casts?.[0] && (
-                                  <Text fontSize="xs" color="fg.muted" textAlign="center">
+                                  <Text color="fg.muted" fontSize="xs" textAlign="center">
                                     {getCastName(c.casts[0], locale)}
                                   </Text>
                                 )}

--- a/src/components/sorter/SongFilters.tsx
+++ b/src/components/sorter/SongFilters.tsx
@@ -417,7 +417,7 @@ export function SongFilters({
             }}
           />
 
-          <Text fontSize="sm" color="fg.muted">
+          <Text color="fg.muted" fontSize="sm">
             {t('settings.character_solo_hint')}
           </Text>
 

--- a/src/components/sorter/SongFilters.tsx
+++ b/src/components/sorter/SongFilters.tsx
@@ -12,6 +12,7 @@ import discographies from '../../../data/discography-info.json';
 import songs from '../../../data/song-info.json';
 
 import { DualListSelector } from './DualListSelector';
+import { CharacterGridSelector } from './CharacterGridSelector';
 import { Badge } from '~/components/ui/badge';
 import { HStack, Stack, Wrap, Box } from 'styled-system/jsx';
 import { isValidSongFilter } from '~/utils/song-filter';
@@ -405,17 +406,20 @@ export function SongFilters({
         <Stack flex="1" gap="4" minW="300px">
           {renderHeader(t('settings.characters'), charactersCount, 'characters', true)}
 
-          <DualListSelector
+          <CharacterGridSelector
             title={t('settings.characters')}
             triggerLabel={t('settings.characters')}
-            items={characterItems}
+            characters={filteredCharacters}
             selectedIds={filters?.characters ?? []}
             onSelectionChange={(ids) => {
               if (!filters) return;
-              setFilters({ ...filters, characters: ids.map(Number) });
+              setFilters({ ...filters, characters: ids });
             }}
-            categories={categories}
           />
+
+          <Text fontSize="sm" color="fg.muted">
+            {t('settings.character_solo_hint')}
+          </Text>
 
           {filters?.characters && filters.characters.length > 0 && (
             <HStack gap="2" pt="2" flexWrap="wrap">

--- a/src/components/sorter/__test__/SongFilters.spec.tsx
+++ b/src/components/sorter/__test__/SongFilters.spec.tsx
@@ -33,6 +33,7 @@ void i18n.use(initReactI18next).init({
         'settings.types': 'Types',
         'settings.artists': 'Artists',
         'settings.characters': 'Characters',
+        'settings.character_solo_hint': 'Tip: enable Type → Solo for solo songs only.',
         'settings.discographies': 'Discographies',
         'settings.songs': 'Songs',
         'settings.select_all': 'Select All',
@@ -71,6 +72,17 @@ describe('SongFilters Component', () => {
     expect(screen.getAllByText('Characters')[0]).toBeInTheDocument();
     expect(screen.getAllByText('Discographies')[0]).toBeInTheDocument();
     expect(screen.getAllByText('Songs')[0]).toBeInTheDocument();
+  });
+
+  it('guides users to the character + solo type combo', () => {
+    const setFilters = vi.fn();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <SongFilters filters={mockFilters} setFilters={setFilters} />
+      </I18nextProvider>
+    );
+
+    expect(screen.getByText('Tip: enable Type → Solo for solo songs only.')).toBeInTheDocument();
   });
 
   it('toggles Series selection', async () => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -49,6 +49,7 @@
       "solo": "Solo"
     },
     "characters": "Characters",
+    "character_solo_hint": "Tip: also enable Type → Solo to sort only a character's solo songs.",
     "discographies": "Discographies",
     "songs": "Songs",
     "logic_and": "Match All",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -47,6 +47,7 @@
       "105ver": "105期 ver."
     },
     "characters": "キャラクター",
+    "character_solo_hint": "ヒント：種別→ソロ曲も選ぶと、キャラのソロ曲だけを並び替えできます。",
     "discographies": "ディスコグラフィ",
     "songs": "楽曲",
     "logic_and": "すべて一致",


### PR DESCRIPTION
## What
Replaces the song-sorter's plain text-list **Character** filter with a grid of character cards, and adds a small hint that surfaces how to sort a single character's solo songs.

### Character grid picker
- Cards show the character's **emblem icon + full name + seiyuu**, reusing the existing `CharacterIcon` / `getPicUrl` assets.
- **Grouped by series** with sticky headers, plus **per-franchise tabs** (All + one per series) so you can view a single franchise at a time without long scrolling.
- Falls back to **top-anchored portrait art** for characters that have no emblem (so faces stay visible instead of cropping to the lower body).
- Selection writes the same `filters.characters[]` state, so the rest of the filter pipeline is unchanged.

### Solo-song guidance
- Adds a hint under the Characters filter: *"Tip: also enable Type → Solo to sort only a character's solo songs."*
- The Character + Type:Solo combo already yields exactly a character's solo songs (verified against data) — it was just undiscoverable. This makes the existing capability findable, which was the original motivation (sorting e.g. a Nijigasaki character's ~10 solo songs).

## Demo

https://github.com/user-attachments/assets/1969951e-80b5-43f8-86a5-82dbdc6028b3

## Notes
- New component: `src/components/sorter/CharacterGridSelector.tsx`.
- i18n: adds `settings.character_solo_hint` to `en` and `ja`.
- Pairs with #60 (filter pickers render reliably) but is independent of it.
